### PR TITLE
Fix order sorting to show assigned orders in main list

### DIFF
--- a/client/pages/Orders.jsx
+++ b/client/pages/Orders.jsx
@@ -84,8 +84,7 @@ export default function Orders(){
       if(!orderId) return;
       const normalizedAssigned = String(orderId).replace(/^#+/, '');
       setPage(1); // refresh orders so assignment is reflected in the list
-      setMeta(prev => ({ ...(prev||{}), total: Math.max(0, (prev?.total || 0) - 1) }));
-      try{ if(window && typeof window.showToast === 'function'){ window.showToast(`Order assigned: ${orderId}`, { type: 'success' }); } }catch(_){}
+            try{ if(window && typeof window.showToast === 'function'){ window.showToast(`Order assigned: ${orderId}`, { type: 'success' }); } }catch(_){}
     }catch(e){}
   }
 

--- a/client/pages/Orders.jsx
+++ b/client/pages/Orders.jsx
@@ -83,7 +83,7 @@ export default function Orders(){
       const { orderId } = payload || {};
       if(!orderId) return;
       const normalizedAssigned = String(orderId).replace(/^#+/, '');
-      setOrders(prev => prev.filter(o => String(o.name||o.order_number||o.id).replace(/^#+/, '') !== String(normalizedAssigned)));
+      setPage(1); // refresh orders so assignment is reflected in the list
       setMeta(prev => ({ ...(prev||{}), total: Math.max(0, (prev?.total || 0) - 1) }));
       try{ if(window && typeof window.showToast === 'function'){ window.showToast(`Order assigned: ${orderId}`, { type: 'success' }); } }catch(_){}
     }catch(e){}

--- a/client/pages/Orders.jsx
+++ b/client/pages/Orders.jsx
@@ -68,10 +68,10 @@ export default function Orders(){
 
   const filtered = useMemo(()=> orders, [orders]);
 
-  // visible respects tab: when tab==='all' hide assigned orders; otherwise filter by status
+  // visible respects tab: when tab==='all' show all orders; otherwise filter by status
   const visible = useMemo(()=>{
     if(!Array.isArray(orders)) return [];
-    if(tab === 'all') return orders.filter(o => getStatusKey(o) !== 'assigned');
+    if(tab === 'all') return orders.slice();
     const targetStatus = STATUS_PARAM_MAP[tab] || tab;
     return orders.filter(o => getStatusKey(o) === targetStatus);
   }, [orders, tab]);

--- a/client/pages/Riders.jsx
+++ b/client/pages/Riders.jsx
@@ -61,7 +61,7 @@ export default function Riders(){
     const labels = [];
     for(let i=2;i>=0;i--){
       const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
-      const key = d.toISOString().slice(0,7); // YYYY-MM
+      const key = `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}`;
       const label = d.toLocaleString(undefined, { month: 'short', year: 'numeric' });
       keys.push(key);
       labels.push(label);

--- a/dist/app.js
+++ b/dist/app.js
@@ -17891,16 +17891,16 @@ function h_() {
             lineNumber: 118,
             columnNumber: 17
           }, this),
-          /* @__PURE__ */ d.jsxDEV("th", { className: "col-total", children: "Total" }, void 0, !1, {
-            fileName: "/app/code/client/pages/Riders.jsx",
-            lineNumber: 119,
-            columnNumber: 17
-          }, this),
           ce.labels.map((X, re) => /* @__PURE__ */ d.jsxDEV("th", { className: "col-month", children: X }, ce.keys[re], !1, {
             fileName: "/app/code/client/pages/Riders.jsx",
-            lineNumber: 121,
+            lineNumber: 120,
             columnNumber: 19
-          }, this))
+          }, this)),
+          /* @__PURE__ */ d.jsxDEV("th", { className: "col-total", children: "Total" }, void 0, !1, {
+            fileName: "/app/code/client/pages/Riders.jsx",
+            lineNumber: 122,
+            columnNumber: 17
+          }, this)
         ] }, void 0, !0, {
           fileName: "/app/code/client/pages/Riders.jsx",
           lineNumber: 117,
@@ -17939,16 +17939,16 @@ function h_() {
               lineNumber: 134,
               columnNumber: 19
             }, this),
-            /* @__PURE__ */ d.jsxDEV("td", { className: "rc-col-total", children: X.assignedOrders ?? 0 }, void 0, !1, {
-              fileName: "/app/code/client/pages/Riders.jsx",
-              lineNumber: 135,
-              columnNumber: 19
-            }, this),
             ce.keys.map((re) => /* @__PURE__ */ d.jsxDEV("td", { className: "rc-col-month", children: X.monthlyCounts && X.monthlyCounts[re] ? X.monthlyCounts[re] : 0 }, re, !1, {
               fileName: "/app/code/client/pages/Riders.jsx",
-              lineNumber: 137,
+              lineNumber: 136,
               columnNumber: 21
-            }, this))
+            }, this)),
+            /* @__PURE__ */ d.jsxDEV("td", { className: "rc-col-total", children: X.assignedOrders ?? 0 }, void 0, !1, {
+              fileName: "/app/code/client/pages/Riders.jsx",
+              lineNumber: 138,
+              columnNumber: 19
+            }, this)
           ] }, X.id, !0, {
             fileName: "/app/code/client/pages/Riders.jsx",
             lineNumber: 133,

--- a/src/services/firebaseAdmin.js
+++ b/src/services/firebaseAdmin.js
@@ -1,6 +1,5 @@
 const admin = require('firebase-admin');
 const log = require('../utils/logger');
-const admin = require('firebase-admin');
 let initialized = false;
 
 function initFirebaseAdmin() {

--- a/src/services/firebaseAdmin.js
+++ b/src/services/firebaseAdmin.js
@@ -1,5 +1,6 @@
 const admin = require('firebase-admin');
 const log = require('../utils/logger');
+const admin = require('firebase-admin');
 let initialized = false;
 
 function initFirebaseAdmin() {


### PR DESCRIPTION
## Purpose

The user reported that when orders are assigned from the dashboard, they disappear from the main order management view and only appear when using the "assigned" filter. The expectation is that all orders, including assigned ones, should appear in the main list sorted with recent orders on top, eliminating the need to use filters to find recently assigned orders.

## Code changes

- **Orders.jsx**: Modified the "all" tab filter to show all orders instead of hiding assigned orders, and updated order assignment handling to refresh the list (reset to page 1) rather than removing orders from the local state
- **Riders.jsx**: Fixed month key generation to use consistent local timezone formatting and reordered table columns to show monthly data before totals
- **apiController.js**: Enhanced rider profile endpoint with comprehensive delivery tracking, improved date handling utilities, and more accurate performance metrics calculation based on actual delivery data
- **dist/app.js**: Updated compiled JavaScript reflecting the frontend changes

The core fix ensures assigned orders remain visible in the main order list while maintaining proper sorting and pagination behavior.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 27`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9d8619d7c0894effa67777bb52cc5e48/quantum-haven)

👀 [Preview Link](https://9d8619d7c0894effa67777bb52cc5e48-quantum-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9d8619d7c0894effa67777bb52cc5e48</projectId>-->
<!--<branchName>quantum-haven</branchName>-->